### PR TITLE
feat!: allow for references contract traits

### DIFF
--- a/admin_sep/src/administratable.rs
+++ b/admin_sep/src/administratable.rs
@@ -5,7 +5,7 @@ use soroban_sdk::{Address, Env, Symbol, symbol_short};
 #[contracttrait(default = Admin, is_extension = true)]
 pub trait Administratable {
     fn admin(env: &Env) -> soroban_sdk::Address;
-    fn set_admin(env: &Env, new_admin: soroban_sdk::Address);
+    fn set_admin(env: &Env, new_admin: &soroban_sdk::Address);
 }
 
 pub const STORAGE_KEY: Symbol = symbol_short!("A");
@@ -21,7 +21,7 @@ impl Administratable for Admin {
     fn admin(env: &Env) -> soroban_sdk::Address {
         unsafe { get(env).unwrap_unchecked() }
     }
-    fn set_admin(env: &Env, new_admin: soroban_sdk::Address) {
+    fn set_admin(env: &Env, new_admin: &soroban_sdk::Address) {
         if let Some(address) = get(env) {
             address.require_auth();
         }

--- a/admin_sep/src/constructor.rs
+++ b/admin_sep/src/constructor.rs
@@ -9,7 +9,7 @@ pub trait Constructable<T: HasAdmin = Address>: crate::Administratable {
     #[allow(unused_variables)]
     fn construct(env: &Env, args: T) {}
     fn constructor(env: &Env, args: T) {
-        Self::set_admin(env, args.admin().clone());
+        Self::set_admin(env, args.admin());
         Self::construct(env, args);
     }
 }


### PR DESCRIPTION
Allows external interface to use values and then the internal contracttraits can use references.

```rust

#[contracttrait]
pub trait Foo {
     fn foo(e: &Env, s: &String);
}

// Generated exported methods will use value instead of reference

impl Contract {
  pub foo(e: &Env, s: String) {
      <Contarct as ContractTrait>::foo(e, &s)
  }

```

