### PR TITLE
Update new wasm hash naming to expected new_wasm_hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,9 @@ Here `Upgradable` is defined as
 
 ```rust
 pub trait Upgradable: Administratable {
-    fn upgrade(env: &Env, wasm_hash: BytesN<32>) {
+    fn upgrade(env: &Env, new_wasm_hash: BytesN<32>) {
         Self::admin(env).require_auth();
-        env.deployer().update_current_contract_wasm(wasm_hash);
+        env.deployer().update_current_contract_wasm(new_wasm_hash);
     }
 }
 ```

--- a/admin_sep/src/upgradable.rs
+++ b/admin_sep/src/upgradable.rs
@@ -5,8 +5,8 @@ use soroban_sdk::contracttrait;
 pub trait Upgradable: Administratable {
     /// Upgrades the contract to a new hash.
     /// Admin Only.
-    fn upgrade(env: &soroban_sdk::Env, wasm_hash: soroban_sdk::BytesN<32>) {
+    fn upgrade(env: &soroban_sdk::Env, new_wasm_hash: soroban_sdk::BytesN<32>) {
         Self::require_admin(env);
-        env.deployer().update_current_contract_wasm(wasm_hash);
+        env.deployer().update_current_contract_wasm(new_wasm_hash);
     }
 }


### PR DESCRIPTION
### What

The argument to `upgrade` should be new_wasm_hash, not wasm_hash, as this is what we're standardizing on per https://developers.stellar.org/docs/build/guides/conventions/upgrading-contracts.

### Why

Scaffold Stellar assumes new_wasm_hash when upgrading contracts, so this function should use that argument.

