### PR TITLE
feat: add release-plz for publishing the admin-sep crate

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,0 +1,59 @@
+name: Release-plz
+
+permissions:
+  pull-requests: write
+  contents: write
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  # Publish the crate and create a git tag + GitHub release when a release PR merges.
+  release-plz-release:
+    name: Release-plz release
+    runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'theahaco' }}
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Run release-plz
+        uses: release-plz/action@v0.5
+        with:
+          command: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  # Keep a release PR open that accumulates version bumps + changelog updates.
+  release-plz-pr:
+    name: Release-plz PR
+    runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'theahaco' }}
+    permissions:
+      contents: write
+      pull-requests: write
+    concurrency:
+      group: release-plz-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Run release-plz
+        uses: release-plz/action@v0.5
+        with:
+          command: release-pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/admin_sep/Cargo.toml
+++ b/admin_sep/Cargo.toml
@@ -4,6 +4,11 @@ version = "0.1.0"
 edition = "2024"
 publish = true
 rust-version = "1.91.0"
+description = "Contract traits for administratable and upgradable Soroban contracts (SEP admin interface)"
+license = "Apache-2.0"
+repository = "https://github.com/theahaco/admin-sep"
+keywords = ["soroban", "stellar", "admin", "contract"]
+categories = ["no-std"]
 
 [lib]
 crate-type = ["rlib"]

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,10 @@
+[workspace]
+# Only release the admin-sep crate; the example contracts are not published.
+release = false
+
+[[package]]
+name = "admin-sep"
+release = true
+changelog_update = true
+git_tag_enable = true
+git_release_enable = true


### PR DESCRIPTION
## Summary
- **`.github/workflows/release-plz.yml`** — two jobs on push to `main`:
  - `release-plz-pr` keeps a release PR open that accumulates version bumps and changelog updates (versioning driven by conventional commits)
  - `release-plz-release` publishes to crates.io and creates the git tag + GitHub release when that release PR merges
- **`release-plz.toml`** — releases are scoped to `admin-sep` only; the two example contracts (`publish = false`) are excluded entirely
- **`admin_sep/Cargo.toml`** — adds the metadata crates.io requires to publish: `description`, `license` (Apache-2.0, matching the repo LICENSE), `repository`, plus keywords/categories

## Notes
- The `CARGO_REGISTRY_TOKEN` secret is already configured on the repo, so releases will work as soon as this merges
- The crate name `admin-sep` is unclaimed on crates.io
- Verified locally with `cargo package -p admin-sep` — packages and compiles cleanly (9 files, 13.8 KiB compressed)

## Test plan
- Merge and confirm the `release-plz-pr` job opens a release PR for `admin-sep` v0.1.0
- Merge the release PR and confirm the crate publishes and the `v0.1.0` tag + GitHub release appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)