### PR TITLE
fix: bump admin-sep to 0.27.0 so release-plz can determine next version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "admin-sep"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "soroban-sdk",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "admin-sep"
-version = "0.2.0"
+version = "0.27.0"
 dependencies = [
  "soroban-sdk",
 ]

--- a/admin_sep/Cargo.toml
+++ b/admin_sep/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "admin-sep"
-version = "0.2.0"
+version = "0.27.0"
 edition = "2024"
 publish = true
 rust-version = "1.91.0"

--- a/admin_sep/Cargo.toml
+++ b/admin_sep/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "admin-sep"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 publish = true
 rust-version = "1.91.0"


### PR DESCRIPTION
## Summary
The Release-plz workflow failed on main with:

> package `admin-sep` not found in the registry, but the git tag v0.1.0 exists. Consider running `cargo publish` manually to publish this package.

The repo has a `v0.1.0` tag and GitHub release (from June), but `admin-sep@0.1.0` was never published to crates.io, so release-plz refuses to compute the next version. Deleting the tag would orphan the existing GitHub release, so instead this bumps the crate to **0.27.0**, tracking the soroban-sdk major version (v27) it targets. With no `v0.27.0` tag present, release-plz treats the package as a first release and proceeds normally.

## Test plan
- After merge, the Release-plz workflow on main should succeed and open a release PR for `admin-sep` v0.27.0
- Merging that release PR publishes to crates.io and creates the `v0.27.0` tag + GitHub release

🤖 Generated with [Claude Code](https://claude.com/claude-code)